### PR TITLE
fix non-ASCII quotes causing rsyslog to break

### DIFF
--- a/rsyslog_elasticsearch.conf
+++ b/rsyslog_elasticsearch.conf
@@ -12,7 +12,7 @@ template(name="logstash-index"
 
 
 # permits to have the part after `/` in programname
-global(parser.permitSlashInProgramName=”on”)
+global(parser.permitSlashInProgramName="on")
 
 # this is for formatting our syslog in JSON with @timestamp
 template(name="plain-syslog"


### PR DESCRIPTION
These are causing a syntax error:

    rsyslogd: error during parsing file /etc/rsyslog.d/rsyslog_elasticsearch.conf, on or before line 15: invalid character '�' in object definition - is there an invalid escape sequence somewhere? [v8.2001.0 try https://www.rsyslog.com/e/2207 ]