### PR TITLE
use our own postrotate script for rsyslogd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN       apt-get -y update && \
 COPY      entrypoint.sh                  /
 COPY	  rsyslog.conf                   /etc/
 COPY      rsyslog_elasticsearch.conf     /etc/rsyslog.d/
+COPY      rsyslog-rotate                 /usr/lib/rsyslog/rsyslog-rotate
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["-n"]

--- a/rsyslog-rotate
+++ b/rsyslog-rotate
@@ -1,0 +1,8 @@
+#!/bin/bash
+# This script is run by logrotate just after rotating (see /etc/logrotate/rsyslogd)
+# It serves to tell rsyslogd to rotate its file descriptors (by sending the HUP signal)
+
+# We need it to overwrite the official script which needs Upstart or SystemD
+
+rsyslogd_pid=$(cat /var/run/rsyslogd.pid)
+kill -HUP $rsyslogd_pid


### PR DESCRIPTION
The original script is like this:

    #!/bin/sh

    if [ -d /run/systemd/system ]; then
        systemctl kill -s HUP rsyslog.service
    else
        invoke-rc.d rsyslog rotate > /dev/null
    fi

Which just serves to send kill -HUP using the appropriate expected layer
(SystemD or Upstart). In our docker container we have none of those,
it was running the Upstart version (invoke-rc.d) which wasn't working.

Here we replace it by a simple script that runs the kill -HUP directly
which is simple and works.

You can test it by launching the image, docker exec-ing into it and then:

1. send some log messages to cause the /var/log/syslog to be created (`for i in $(seq 10); do logger -n localhost -d -P 514 "oh noes something bad is happening again and the logs are being flooded again and again, what will happen to us, omg omg $i"; done`)

2. rotate the /var/log/syslog file manually: `mv /var/log/syslog /var/log/syslog.1`

3. run the postrotate script: `/usr/lib/rsyslog/rsyslog-rotate`

4. send some new log messages (repeat step 1)

Expected: there should be a new `/var/log/syslog` file with the new messages