### PR TITLE
Switch to week based indices (and other minor improvements)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Also supports Maestro-ng formatted environment variables
  
 if [ -z "$ESLOG_HOST" ]; then
@@ -15,9 +17,9 @@ if [ -z "$ESLOG_ES_PORT" ]; then
 fi
 
 if [ -n "$ESLOG_HOST" ]; then
-	sed s/myserver.local/$ESLOG_HOST/g -i /etc/rsyslog.d/rsyslog_elasticsearch.conf
+	sed "s/myserver.local/$ESLOG_HOST/g" -i /etc/rsyslog.d/rsyslog_elasticsearch.conf
 	if [ -n "$ESLOG_ES_PORT" ]; then
-		sed s/9200/$ESLOG_ES_PORT/g -i /etc/rsyslog.d/rsyslog_elasticsearch.conf
+		sed "s/serverport=\"9200\"/serverport=\"$ESLOG_ES_PORT\"/g" -i /etc/rsyslog.d/rsyslog_elasticsearch.conf
 	fi
 	if [ -n "$ESLOG_ES_USE_HTTPS" ]; then
 		sed s/usehttps=\"on\"/usehttps=\"$ESLOG_ES_USE_HTTPS\"/g -i /etc/rsyslog.d/rsyslog_elasticsearch.conf
@@ -28,6 +30,6 @@ fi
 service cron start
 
 # we make sure there's no PID file remaining, which may happen if you manually restart the docker container 
-rm /var/run/rsyslogd.pid
+rm -f /var/run/rsyslogd.pid
 
 /usr/sbin/rsyslogd $@

--- a/readme.md
+++ b/readme.md
@@ -30,3 +30,13 @@ On a docker 1.8 machine (which supports tagging):
 	docker run -d --log-driver=syslog --log-opt syslog-address=tcp://{hostip}:5514 --log-opt syslog-tag="redis" redis
 
 	
+
+## Testing
+
+You can send some test logs to test that everything is working by
+Docker exec'ing and sending a few messages with the:
+
+    seq 10 | xargs logger -P 514 -n localhost hello message:
+
+.. and then checking the logs and the Elasticsearch indices
+to see if everything is working.

--- a/rsyslog_elasticsearch.conf
+++ b/rsyslog_elasticsearch.conf
@@ -1,13 +1,14 @@
 module(load="omelasticsearch") # for outputting to Elasticsearch
-# this is for index names to be like: logstash-YYYY.MM.DD
+# this is for index names to be like: logstash-YYYY.MM.wWW (where WW is the week number)
 template(name="logstash-index"
   type="list") {
     constant(value="logstash-")
     property(name="timereported" dateFormat="rfc3339" position.from="1" position.to="4")
     constant(value=".")
     property(name="timereported" dateFormat="rfc3339" position.from="6" position.to="7")
-    constant(value=".")
-    property(name="timereported" dateFormat="rfc3339" position.from="9" position.to="10")
+    constant(value=".w")
+    # here we use the week number to avoid creating lots of shards on Elasticsearch
+    property(name="timereported" dateFormat="week")
 }
 
 


### PR DESCRIPTION
Summary of changes:

* switch the config to use `.w$WEEK_OF_YEAR` instead of `.$DAY`
* made entrypoint.sh more robust (I recently had to debug a bad input thing, the `sed` command was failing silently)
* added note in readme on how to test it